### PR TITLE
Join sources with semicolons

### DIFF
--- a/lib/barber/precompiler.rb
+++ b/lib/barber/precompiler.rb
@@ -88,7 +88,7 @@ module Barber
     end
 
     def source
-      @source ||= sources.map(&:read).join("\n")
+      @source ||= sources.map(&:read).join("\n;\n")
     end
   end
 end


### PR DESCRIPTION
prevents awful things like
http://stackoverflow.com/questions/8625220/typeerror-with-two-consecutive-self-executing-anonymous-functions
