### PR TITLE
Instruction to include barber for rake-piepeline-web-filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ subsituted for procs/lambda where needed. Here's how you can get
 precompilation of your ember templates with rake-pipeline-web-filters:
 
 ```ruby
+require 'barber'
+
 match "**/*.handlebars" do
   handlebars :wrapper_proc => Barber::Ember::FilePrecompiler
 end


### PR DESCRIPTION
Makes it easier for ruby newbies if you're explicit about including barber in the Assetfile.
