### PR TITLE
Fix CS strings with {{helper key="value"}}

### DIFF
--- a/lib/barber/precompiler.rb
+++ b/lib/barber/precompiler.rb
@@ -58,7 +58,9 @@ module Barber
 
     def sanitize_with_regexp(template)
       if template.respond_to? :gsub
-        template.gsub(/\\n/,"\n")
+        sanitized = template.gsub(/\\n/,"\n")
+        sanitized = sanitized.gsub(/\\["']/, '"')
+        sanitized
       else
         template
       end

--- a/test/precompiler_test.rb
+++ b/test/precompiler_test.rb
@@ -25,6 +25,11 @@ class PrecompilerTest < MiniTest::Unit::TestCase
     assert result
   end
 
+  def test_handles_coffeescript_strings_with_qoutes_in_helpers
+    result = compile template_with_coffeescript_qoutes_in_helpers
+    assert result
+  end
+
   def test_handles_prescaped_JSON_strings
     result = compile template_with_prescaped_JSON_strings
     assert result
@@ -100,6 +105,10 @@ class PrecompilerTest < MiniTest::Unit::TestCase
 
   def template_with_multiline_coffeescript_strings
     '<h2>{{unbound view.title}}</h2>\n<ul>\n  {{#each view.content}}\n    {{view view.resultItemView\n      contentBinding="this"\n      selectedItemBinding="view.selectedItem"}}\n  {{/each}}\n</ul>'
+  end
+
+  def template_with_coffeescript_qoutes_in_helpers
+    '<li {{action showContextMenu this target=\"view\"}}Foo</li>'
   end
 
   def sanitized_template_with_multiline_coffeescript_strings


### PR DESCRIPTION
Hey @tchak, I wanted to run this by you before committing it to master. Apparently newer versions of handlebars cannot contain literal '\"' in them. So if you write coffeescript like this:

``` coffeescript
Ember.View.extend
  template: Ember.Handlebars.compile """
    {{action target="view"}}
  """
```

You'll get a lovely error. I updated the regex sanitization to remove all literal '\"' from the templates. If you're ok with this please merge it and we can release version 0.4.2.
