### PR TITLE
Fix handlebars-source dependency version

### DIFF
--- a/barber.gemspec
+++ b/barber.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Barber::VERSION
 
   gem.add_dependency "execjs"
-  gem.add_dependency "handlebars-source"
+  gem.add_dependency "handlebars-source", [">= 1.0.0.rc.3"]
   gem.add_dependency "ember-source"
 
   gem.add_development_dependency "rake"


### PR DESCRIPTION
`bundle install` is failed.

``` sh
$ cd barber
$ bundle install
Bundler could not find compatible versions for gem "handlebars-source":
  In Gemfile:
    barber (>= 0) ruby depends on
      handlebars-source (< 1.0.0.rc4, >= 1.0.0.rc3) ruby

    barber (>= 0) ruby depends on
      handlebars-source (1.0.0)
```

This cause is that `gem.add_dependency "handlebars-source"` in barber.gemspec requires released version.
But handlebars-source is pre-released version now latest.

So I allow pre-released version of handlebars-source.
