### PR TITLE
Dependencies should be specified in .gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in handlebars-precompiler.gemspec
 gemspec
 
-gem 'handlebars-source', '1.0.0.rc4'
 gem 'therubyrhino', platform: :jruby


### PR DESCRIPTION
I think it's better if dependencies are only specified in the .gemspec file.
