### PR TITLE
Restrict handlebars-suorce < 3

### DIFF
--- a/barber.gemspec
+++ b/barber.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Barber::VERSION
 
   gem.add_dependency "execjs"
-  gem.add_dependency "handlebars-source", [">= 1.0.0.rc.4"]
+  gem.add_dependency "handlebars-source", [">= 1.0.0.rc.4", "< 3"]
   gem.add_dependency "ember-source"
 
   gem.add_development_dependency "rake"


### PR DESCRIPTION
handlebars-source 3.0.0 throws the following error:

```
ReferenceError: Can't find variable: window
```