### PR TITLE
Make handlebars precompilation into optional

### DIFF
--- a/barber.gemspec
+++ b/barber.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |gem|
   gem.version       = Barber::VERSION
 
   gem.add_dependency "execjs"
-  gem.add_dependency "handlebars-source", [">= 1.0.0.rc.4", "< 3.1"]
   gem.add_dependency "ember-source"
 
   gem.add_development_dependency "rake"
+  gem.add_development_dependency "handlebars-source", [">= 1.0.0.rc.4", "< 3.1"]
   gem.add_development_dependency "simplecov"
   gem.add_development_dependency "mocha", "~> 1.0"
   gem.add_development_dependency "appraisal"

--- a/lib/barber.rb
+++ b/lib/barber.rb
@@ -1,6 +1,5 @@
 require "barber/version"
 
-require 'handlebars/source'
 require 'ember/source'
 
 require "barber/precompiler"

--- a/lib/barber/ember/precompiler.rb
+++ b/lib/barber/ember/precompiler.rb
@@ -11,7 +11,7 @@ module Barber
       end
 
       def sources
-        [precompiler, handlebars, ember_template_precompiler]
+        super + [ember_template_precompiler]
       end
     end
   end

--- a/lib/barber/javascripts/ember_precompiler.js
+++ b/lib/barber/javascripts/ember_precompiler.js
@@ -9,7 +9,7 @@ function require() {
 // Precompiler
 var Barber = {
   precompile: function(string) {
-    var Compiler = exports.precompile ? exports : require(/* htmlbars */);
+    var Compiler = exports.precompile ? exports : require(/* ember-template-compiler */);
 
     return Compiler.precompile(string, false).toString();
   }

--- a/lib/barber/javascripts/handlebars_precompiler.js
+++ b/lib/barber/javascripts/handlebars_precompiler.js
@@ -1,6 +1,9 @@
 // Precompiler
 var Barber = {
   precompile: function(string) {
+    if (typeof Handlebars === 'undefined') {
+      throw '`Handlebars` is missing. `gem "handlebars-source"` is required in your `Gemfile`.';
+    }
     return Handlebars.precompile(string).toString();
   }
 };

--- a/lib/barber/precompiler.rb
+++ b/lib/barber/precompiler.rb
@@ -20,7 +20,9 @@ module Barber
     end
 
     def sources
-      [precompiler, handlebars]
+      sources = [precompiler]
+      sources << handlebars if handlebars_available?
+      sources
     end
 
     def handlebars
@@ -82,6 +84,14 @@ if (typeof window === 'undefined') {
 };
 #{sources.map(&:read).join("\n;\n")}
       SOURCE
+    end
+
+    def handlebars_available?
+      require "handlebars/source" # handlebars precompilation is optional feature.
+    rescue LoadError
+      # noop
+    ensure
+      return !!defined?(Handlebars::Source)
     end
   end
 end

--- a/test/precompiler_test.rb
+++ b/test/precompiler_test.rb
@@ -86,6 +86,19 @@ class PrecompilerTest < MiniTest::Unit::TestCase
     assert_equal "Foo", custom_compiler.compile("{{hello}}")
   end
 
+  def test_has_an_easy_to_customize_public_interface
+    custom_compiler = Class.new Barber::Precompiler do
+      # Stub for non-handlebars environment
+      def handlebars_available?
+        false
+      end
+    end
+
+    assert_raises Barber::PrecompilerError do
+      custom_compiler.compile('{{hello}}')
+    end
+  end
+
   private
   def compile(template)
     Barber::Precompiler.compile template


### PR DESCRIPTION
Now Ember.js doesn't depend on Handlebars.
So I remove handlebars dependency. (It will be an optional feature.)
ref: #34 

@tchak 
If you're sure, I want to release a version with this commit.