### PR TITLE
Support `Precompiler#compiler_version`

### DIFF
--- a/lib/barber/ember/precompiler.rb
+++ b/lib/barber/ember/precompiler.rb
@@ -13,6 +13,22 @@ module Barber
       def sources
         super + [ember_template_precompiler]
       end
+
+      def compiler_version
+        cache_key = "ember-source:#{::Ember::VERSION}"
+
+        if handlebars_version
+          "handlebars:#{handlebars_version}/#{cache_key}"
+        else
+          cache_key
+        end
+      end
+
+      private
+
+      def handlebars_version
+        @handlebars_version ||= context.eval('typeof require !== "undefined" && require("handlebars") && require("handlebars").VERSION');
+      end
     end
   end
 end

--- a/lib/barber/precompiler.rb
+++ b/lib/barber/precompiler.rb
@@ -29,6 +29,10 @@ module Barber
       @handlebars ||= File.new(Handlebars::Source.bundled_path)
     end
 
+    def compiler_version
+      "handlebars:#{handlebars_version}"
+    end
+
     private
     # This method handles different types of user input. The precompiler
     # can be called from many different places which create interesting
@@ -92,6 +96,10 @@ if (typeof window === 'undefined') {
       # noop
     ensure
       return !!defined?(Handlebars::Source)
+    end
+
+    def handlebars_version
+      @handlebars_version ||= context.eval('Handlebars.VERSION')
     end
   end
 end

--- a/test/ember/precompiler_test.rb
+++ b/test/ember/precompiler_test.rb
@@ -12,6 +12,12 @@ class EmberPrecompilerTest < MiniTest::Unit::TestCase
       "Ember precompile should inherit from Barber::Precompiler"
   end
 
+  def test_compiler_version
+    assert Barber::Ember::Precompiler.new.compiler_version
+  end
+
+  private
+
   def compile(template)
     Barber::Ember::Precompiler.compile template
   end

--- a/test/precompiler_test.rb
+++ b/test/precompiler_test.rb
@@ -99,7 +99,12 @@ class PrecompilerTest < MiniTest::Unit::TestCase
     end
   end
 
+  def test_compiler_version
+    assert Barber::Precompiler.new.compiler_version
+  end
+
   private
+
   def compile(template)
     Barber::Precompiler.compile template
   end


### PR DESCRIPTION
This will identify compiler version.
It is used as cache key for preompile.