### PR TITLE
Faster `handlebars_version`

### DIFF
--- a/lib/barber/ember/precompiler.rb
+++ b/lib/barber/ember/precompiler.rb
@@ -27,7 +27,9 @@ module Barber
       private
 
       def handlebars_version
-        @handlebars_version ||= context.eval('typeof require !== "undefined" && require("handlebars") && require("handlebars").VERSION');
+        return @handlebars_version if defined?(@handlebars_version)
+
+        @handlebars_version = context.eval('typeof require !== "undefined" && require("handlebars") && require("handlebars").VERSION');
       end
     end
   end


### PR DESCRIPTION
When `handlebars_version == nil`, it re-evaluates each method call.
This patch makes 500x faster than previous version.