### PR TITLE
Make `Barber::Precompiler.handlebars_available?` public

### DIFF
--- a/lib/barber/precompiler.rb
+++ b/lib/barber/precompiler.rb
@@ -12,6 +12,14 @@ module Barber
         instance.compiler_version
       end
 
+      def handlebars_available?
+        require 'handlebars/source' # handlebars precompilation is optional feature.
+      rescue LoadError => e
+        raise e unless ['cannot load such file -- handlebars/source', 'no such file to load -- handlebars/source'].include?(e.message)
+      ensure
+        return !!defined?(Handlebars::Source)
+      end
+
       private
 
       def instance
@@ -31,7 +39,7 @@ module Barber
 
     def sources
       sources = [precompiler]
-      sources << handlebars if handlebars_available?
+      sources << handlebars if self.class.handlebars_available?
       sources
     end
 
@@ -101,14 +109,6 @@ if (typeof self === 'undefined') {
 };
 #{sources.map(&:read).join("\n;\n")}
       SOURCE
-    end
-
-    def handlebars_available?
-      require "handlebars/source" # handlebars precompilation is optional feature.
-    rescue LoadError => e
-      raise e unless ['cannot load such file -- handlebars/source', 'no such file to load -- handlebars/source'].include?(e.message)
-    ensure
-      return !!defined?(Handlebars::Source)
     end
 
     def handlebars_version

--- a/test/precompiler_test.rb
+++ b/test/precompiler_test.rb
@@ -66,6 +66,10 @@ class PrecompilerTest < MiniTest::Unit::TestCase
     assert result
   end
 
+  def test_handlebars_available_works
+    assert Barber::Precompiler.handlebars_available?
+  end
+
   def test_raises_an_error_on_bad_templates
     assert_raises Barber::PrecompilerError do
       compile "Hello {{"
@@ -89,7 +93,7 @@ class PrecompilerTest < MiniTest::Unit::TestCase
   def test_has_an_easy_to_customize_public_interface
     custom_compiler = Class.new Barber::Precompiler do
       # Stub for non-handlebars environment
-      def handlebars_available?
+      def self.handlebars_available?
         false
       end
     end


### PR DESCRIPTION
It is useful for optional feature detection from other gems.