### PR TITLE
passing in compilation options to htmlbars template compilation

### DIFF
--- a/lib/barber/ember/precompilers.rb
+++ b/lib/barber/ember/precompilers.rb
@@ -2,19 +2,19 @@ module Barber
   module Ember
     class InlinePrecompiler
       class << self
-        def call(template)
-          "Ember.Handlebars.template(#{compile(template)})"
+        def call(template, options = nil)
+          "Ember.Handlebars.template(#{compile(template, options)})"
         end
 
-        def compile(template)
-          Barber::Ember::Precompiler.compile template
+        def compile(template, options = nil)
+          Barber::Ember::Precompiler.compile template, options
         end
       end
     end
 
     class FilePrecompiler < InlinePrecompiler
       class << self
-        def call(template)
+        def call(template, options = nil)
           "#{super};"
         end
       end

--- a/lib/barber/javascripts/ember_precompiler.js
+++ b/lib/barber/javascripts/ember_precompiler.js
@@ -8,9 +8,9 @@ function require() {
 
 // Precompiler
 var Barber = {
-  precompile: function(string) {
+  precompile: function(string, options) {
     var Compiler = exports.precompile ? exports : require(/* ember-template-compiler */);
 
-    return Compiler.precompile(string, false).toString();
+    return Compiler.precompile(string, options).toString();
   }
 };

--- a/lib/barber/precompiler.rb
+++ b/lib/barber/precompiler.rb
@@ -4,8 +4,8 @@ require 'json'
 module Barber
   class Precompiler
     class << self
-      def compile(template)
-        instance.compile(template)
+      def compile(template, options = nil)
+        instance.compile(template, options)
       end
 
       def compiler_version
@@ -27,8 +27,8 @@ module Barber
       end
     end
 
-    def compile(template)
-      context.call precompile_function, sanitize(template)
+    def compile(template, options = nil)
+      context.call precompile_function, sanitize(template), options
     rescue ExecJS::ProgramError => ex
       raise Barber::PrecompilerError.new(template, ex)
     end

--- a/lib/barber/precompilers.rb
+++ b/lib/barber/precompilers.rb
@@ -1,12 +1,12 @@
 module Barber
   class InlinePrecompiler
     class << self
-      def call(template)
-        "Handlebars.template(#{compile(template)})"
+      def call(template, options = nil)
+        "Handlebars.template(#{compile(template, options)})"
       end
 
-      def compile(template)
-        Barber::Precompiler.compile template
+      def compile(template, options = nil)
+        Barber::Precompiler.compile template, options
       end
     end
   end


### PR DESCRIPTION
this is required to make `moduleName` meta key available in the
compiled template to allow view tree inspection.

the problem is reported at
emberjs/ember-inspector#419