### PR TITLE
Drop Ruby 2.0.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - "2.0.0"
   - "2.1"
   - "2.2"
   - "2.3.0"


### PR DESCRIPTION
Ruby 2.0.0's support has ended.
https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/