### PR TITLE
Fix for ember-source 2.7.0

### DIFF
--- a/lib/barber/javascripts/ember_precompiler.js
+++ b/lib/barber/javascripts/ember_precompiler.js
@@ -3,13 +3,31 @@ var module = this.module || {exports: null};
 
 function require() {
   // ember-template-compiler only requires which 'handlebars' or 'htmlbars'.
-  return module.exports || Handlebars;
+
+  // Ember 1.9
+  if (exports.precompile) {
+    return exports;
+  }
+  // Ember 2.7 or later
+  if (typeof Ember !== 'undefined') {
+    return Ember.Handlebars;
+  }
+  // Ember >= 1.10, < 2.7
+  if (module.exports) {
+    return module.exports;
+  }
+  // Older Ember
+  if (typeof Handlebars !== 'undefined') {
+    return Handlebars;
+  }
+
+  throw '`ember-template-compiler` is missing.';
 }
 
 // Precompiler
 var Barber = {
   precompile: function(string, options) {
-    var Compiler = exports.precompile ? exports : require(/* ember-template-compiler */);
+    var Compiler = require(/* ember-template-compiler */);
 
     return Compiler.precompile(string, options).toString();
   }

--- a/test/ember/precompiler_test.rb
+++ b/test/ember/precompiler_test.rb
@@ -28,6 +28,21 @@ class EmberPrecompilerTest < Minitest::Test
     assert_match %r{ember:1\.11\.0}, compiler.compiler_version
   end
 
+  def test_for_handlebars_anavailable
+    if  Gem::Version.new(Ember::VERSION) < Gem::Version.new('1.10')
+      skip "This ember-source (#{Ember::VERSION}) is too old to assert without Handlebars."
+    end
+
+    custom_compiler = Class.new Barber::Ember::Precompiler do
+      # Stub for non-handlebars environment
+      def self.handlebars_available?
+        false
+      end
+    end
+
+    assert_match %r{function\(\)}, custom_compiler.compile('{{hello}}')
+  end
+
   private
 
   def compile(template)


### PR DESCRIPTION
Ember.js 2.7 has no namespace `Handlebars` in globally.
Please use it from `Ember` namespace.