### PR TITLE
Specify jRuby version on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - "2.2.9"
   - "2.3.6"
   - "2.4.3"
-  - jruby
+  - jruby-9.1.15.0
 before_install:
   - gem update bundler
 env:

--- a/lib/barber/precompiler.rb
+++ b/lib/barber/precompiler.rb
@@ -112,6 +112,10 @@ if (Object.defineProperty) {
   Object.defineProperty(Error, 'stackTraceLimit', {configurable: false});
   Object.defineProperty(Error, 'prepareStackTrace', {configurable: false});
 }
+// Workaround for `ExecJS::RubyRhinoRuntime`. It has no `setTimeout` but backburner references `setTimeout`.
+if (typeof setTimeout === 'undefined') {
+  setTimeout = function(fn) { fn(); };
+};
 #{sources.map(&:read).join("\n;\n")}
       SOURCE
     end

--- a/lib/barber/precompiler.rb
+++ b/lib/barber/precompiler.rb
@@ -38,7 +38,8 @@ module Barber
     end
 
     def sources
-      sources = [precompiler]
+      sources = []
+      sources << precompiler
       sources << handlebars if self.class.handlebars_available?
       sources
     end
@@ -99,25 +100,38 @@ module Barber
     end
 
     def source
+      source_fixes + sources.map(&:read).join("\n;\n")
+    end
+
+    def source_fixes
+      shims = []
+
       # hbs 3 has no reference to `window` and `self`.
-      <<-SOURCE
+      shims << <<-JS
 if (typeof window === 'undefined') {
   window = this;
-};
+}
 if (typeof self === 'undefined') {
   self = this;
-};
-// Workaround for `ExecJS::RubyRhinoRuntime`. It throws an error: `Invalid JavaScript value of type org.mozilla.javascript.MemberBox` on inherit `Error`.
+}
+      JS
+
+      # Workaround for `ExecJS::RubyRhinoRuntime`. It throws an error: `Invalid JavaScript value of type org.mozilla.javascript.MemberBox` on inherit `Error`.
+      shims << <<-JS
 if (Object.defineProperty) {
   Object.defineProperty(Error, 'stackTraceLimit', {configurable: false});
   Object.defineProperty(Error, 'prepareStackTrace', {configurable: false});
 }
-// Workaround for `ExecJS::RubyRhinoRuntime`. It has no `setTimeout` but backburner references `setTimeout`.
+      JS
+
+      # Workaround for `ExecJS::RubyRhinoRuntime`. It has no `setTimeout` but backburner references `setTimeout`.
+      shims << <<-JS
 if (typeof setTimeout === 'undefined') {
   setTimeout = function(fn) { fn(); };
-};
-#{sources.map(&:read).join("\n;\n")}
-      SOURCE
+}
+      JS
+
+      shims.join("\n")
     end
 
     def handlebars_version


### PR DESCRIPTION
To fix the followring error:
> $ rvm use jruby --install --binary --fuzzy
> Unknown ruby string (do not know how to handle): jruby-9.1.15.0200.

https://travis-ci.org/tchak/barber/jobs/326895117