### PR TITLE
Add license to gemspec for easier automatic discovery

### DIFF
--- a/barber.gemspec
+++ b/barber.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Handlebars precompilation}
   gem.summary       = %q{Handlebars precompilation toolkit}
   gem.homepage      = "https://github.com/tchak/barber"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
The LICENSE file already defines this gem as MIT, but this adds that info to the gemspec as well